### PR TITLE
feat: FetchCurrentWeatherUseCase 구현하기

### DIFF
--- a/GoodMorning/GoodMorning.xcodeproj/project.pbxproj
+++ b/GoodMorning/GoodMorning.xcodeproj/project.pbxproj
@@ -64,6 +64,7 @@
 		80F90CFB2A8F092C007E1D23 /* UIImage+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80F90CFA2A8F092C007E1D23 /* UIImage+.swift */; };
 		80F90CFD2A8F095A007E1D23 /* Images.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80F90CFC2A8F095A007E1D23 /* Images.swift */; };
 		80F90D012A8F3E7B007E1D23 /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80F90D002A8F3E7B007E1D23 /* HomeViewController.swift */; };
+		871281832AF2AF5E00B303E4 /* FetchCurrentWeatherUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 871281822AF2AF5E00B303E4 /* FetchCurrentWeatherUseCase.swift */; };
 		8728F3C82A57F3280064A655 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 8728F3C72A57F3280064A655 /* .swiftlint.yml */; };
 		873555242A694AB40027A847 /* Requestable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 873555232A694AB40027A847 /* Requestable.swift */; };
 		873555262A694ABA0027A847 /* Responsable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 873555252A694ABA0027A847 /* Responsable.swift */; };
@@ -184,6 +185,7 @@
 		80F90CFA2A8F092C007E1D23 /* UIImage+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+.swift"; sourceTree = "<group>"; };
 		80F90CFC2A8F095A007E1D23 /* Images.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Images.swift; sourceTree = "<group>"; };
 		80F90D002A8F3E7B007E1D23 /* HomeViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
+		871281822AF2AF5E00B303E4 /* FetchCurrentWeatherUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchCurrentWeatherUseCase.swift; sourceTree = "<group>"; };
 		8728F3C72A57F3280064A655 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		873555232A694AB40027A847 /* Requestable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Requestable.swift; sourceTree = "<group>"; };
 		873555252A694ABA0027A847 /* Responsable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Responsable.swift; sourceTree = "<group>"; };
@@ -739,6 +741,7 @@
 		87EA72A02ACBE6D50042DD88 /* UseCases */ = {
 			isa = PBXGroup;
 			children = (
+				871281822AF2AF5E00B303E4 /* FetchCurrentWeatherUseCase.swift */,
 			);
 			path = UseCases;
 			sourceTree = "<group>";
@@ -1055,6 +1058,7 @@
 				8735552A2A694FED0027A847 /* CurrentWeatherEndPoint.swift in Sources */,
 				8744BAE32A8E0B0100449FD9 /* CALayer+.swift in Sources */,
 				873555282A694FBA0027A847 /* RequestResponsable.swift in Sources */,
+				871281832AF2AF5E00B303E4 /* FetchCurrentWeatherUseCase.swift in Sources */,
 				80B699632ACBE53F00CD3F8C /* MorningRoutine+CoreDataClass.swift in Sources */,
 				80F90C662A7BC48E007E1D23 /* NetworkSessionProvidable.swift in Sources */,
 				80F90CFD2A8F095A007E1D23 /* Images.swift in Sources */,

--- a/GoodMorning/GoodMorning/Data/Repositories/DefaultCurrentLocationRepository.swift
+++ b/GoodMorning/GoodMorning/Data/Repositories/DefaultCurrentLocationRepository.swift
@@ -32,4 +32,5 @@ extension DefaultCurrentLocationRepository: CurrentLocationRepository {
 
         return coreLocationResult
     }
+
 }

--- a/GoodMorning/GoodMorning/Domain/UseCases/FetchCurrentWeatherUseCase.swift
+++ b/GoodMorning/GoodMorning/Domain/UseCases/FetchCurrentWeatherUseCase.swift
@@ -1,0 +1,44 @@
+//
+//  FetchCurrentWeatherUseCase.swift
+//  GoodMorning
+//
+//  Created by Miro on 11/2/23.
+//
+
+import Foundation
+
+final class FetchCurrentWeatherUseCase {
+
+    private let weatherRepository: WeatherRepository
+    private let locationRepository: CurrentLocationRepository
+
+    init(weatherRepository: WeatherRepository, locationRepository: CurrentLocationRepository) {
+        self.weatherRepository = weatherRepository
+        self.locationRepository = locationRepository
+    }
+
+    func execute() async throws -> CurrentWeather {
+
+        let locationResult = locationRepository.fetchCurrentLocation()
+
+        switch locationResult {
+        case .success(let coordinate):
+            let currentWeatherResult = try await weatherRepository.fetchCurrentWeather(
+                in: coordinate ?? Coordinate(longitude: "0", latitude: "0")
+            )
+
+            switch currentWeatherResult {
+            case .success(let weather):
+                return weather
+            case .failure(let networkError):
+                throw networkError
+            }
+
+        case .failure(let error):
+            throw error
+        case .none:
+            throw LocationError.unknowned
+        }
+    }
+
+}

--- a/GoodMorning/GoodMorning/Domain/UseCases/FetchCurrentWeatherUseCase.swift
+++ b/GoodMorning/GoodMorning/Domain/UseCases/FetchCurrentWeatherUseCase.swift
@@ -18,26 +18,30 @@ final class FetchCurrentWeatherUseCase {
     }
 
     func execute() async throws -> CurrentWeather {
-
         let locationResult = locationRepository.fetchCurrentLocation()
 
         switch locationResult {
         case .success(let coordinate):
-            let currentWeatherResult = try await weatherRepository.fetchCurrentWeather(
-                in: coordinate ?? Coordinate(longitude: "0", latitude: "0")
-            )
+            guard let coordinate else { throw LocationError.unknowned }
+            let currentWeather = try await currentWeather(in: coordinate)
 
-            switch currentWeatherResult {
-            case .success(let weather):
-                return weather
-            case .failure(let networkError):
-                throw networkError
-            }
+            return currentWeather
 
         case .failure(let error):
             throw error
         case .none:
             throw LocationError.unknowned
+        }
+    }
+
+    func currentWeather(in coordinate: Coordinate) async throws -> CurrentWeather {
+        let currentWeatherResult = try await weatherRepository.fetchCurrentWeather(in: coordinate)
+
+        switch currentWeatherResult {
+        case .success(let weather):
+            return weather
+        case .failure(let error):
+            throw error
         }
     }
 


### PR DESCRIPTION
써니 안녕하세요, 간단하게 FetchCurrentWeatherUseCase를 구현해봤습니다.
근데, 사실 뻔하다고 생각을해서 구현을 했었는데, 생각보다 고민이 많이 되었고, 결과적으로 매우 불만족스러운 코드가 나온거 같아요..

제가 왜 그렇게 생각했는 지 말씀드리겠습니다.

먼저 제가 작성한 코드는 아래와 같습니다.
```swift
func execute() async throws -> CurrentWeather {

        let locationResult = locationRepository.fetchCurrentLocation()

        switch locationResult {
        case .success(let coordinate):
            let currentWeatherResult = try await weatherRepository.fetchCurrentWeather(
                in: coordinate ?? Coordinate(longitude: "0", latitude: "0")
            )

            switch currentWeatherResult {
            case .success(let weather):
                return weather
            case .failure(let networkError):
                throw networkError
            }

        case .failure(let error):
            throw error
        case .none:
            throw LocationError.unknowned
        }
    }
```

일단 제가 위 코드에서 불만족스러운 부분은 두 가지가 있습니다.
1. Switch 문 안의 Switch문(중첩 Switch 문)
2. case .none의 존재

먼저 중첩 switch문의 경우 어쩔 수 없이 Result 타입 안에서 Result 타입을 활용해야되기 때문에 불가피하다고 생각이 들어서 그냥 넘어가기로 했습니다. 

그러나, case .none의 존재의 경우 받아온 Result 타입이 Optional이기에 생기는 문제점입니다.
```swift
Result<Coordinate, LocationError>?
```

그래서 Optional을 없애주기위해서 코드를 살펴보니, 어쩔 수 없이 저희가 escaping closure와 Result 타입을 활용하기 위해서 DispatchGroup을 활용했기에 (즉, closure 안에서 변수를 initialize하기에) 생기는 문제점이있습니다. 그래서 DefaultCurrentLocationRepository의 fetchCurrentLocation()을 escaping closure로 구현해주려고 했는데, 결과적으로는 UseCase에서 async await을 활용하기에 서로 맞지 않는다는 생각이 들었습니다.

즉, completionHandler와 async await를 혼용해서 활용했기에 생기는 문제점인 거 같습니다🥲 애초에 locationMananger에서 completionHandler를 활용했으므로 전체를 completionHandler로 받았어야했나 라는 생각도 드네요..ㅜㅜ 아니면 locationManager를 async await로 구현을 했어야했을지도!!

암튼 저의 코드 넉두리를 이러합니다. 써니의 의견은 어떠신 지 궁금합니다:) 